### PR TITLE
feat: added `ObservedDecoratorType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ instance.myProperty = 'c';
 ```typescript
 export class MyClass {
 
-    @Observed({ type: 'subject' }) myNumber: number;
+    @Observed('subject') myNumber: number;
     readonly myNumber$!: Observable<number>;
 
     constructor() {}
@@ -175,11 +175,15 @@ instance.animal = { mass: 10, color: 'blue' };
 
 ## Options
 
-`Observed()` Decorator takes in an optional parameter for `options`.
+`Observed()` Decorator takes in an optional parameter for `options`. `options` can either be a `string` of the subject type, or an `Object` with more parameters as defined below.
 
 ```typescript
-class A {
-    @Observed({ type: 'subject' }) prop = '';
+class MyClass {
+    // using the subject type:
+    @Observed('subject') propA = '';
+
+    // using the options object:
+    @Observed({ type: 'subject' }) propB = '';
 }
 ```
 
@@ -189,4 +193,4 @@ class A {
 | type | • `'subject'`<br/> • `'replay'`<br/> • `'behavior'` | Default value is `'behavior'` |
 | replayOptions | See [RxJS ReplaySubject](https://rxjs-dev.firebaseapp.com/api/index/class/ReplaySubject) | Should only be used with `type: 'replay'`|
 
-The default value for `options` is `{ type: 'behavior' }`.
+The default value for `options` is `'behavior'`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { Observed } from './observed.decorator';
-export { ObservedDecoratorOptions } from './observed-decorator-options.interface';
+export { ObservedDecoratorOptions, ObservedDecoratorType } from './observed-decorator-options.interface';

--- a/src/observed-decorator-options.interface.ts
+++ b/src/observed-decorator-options.interface.ts
@@ -1,7 +1,9 @@
 import { SchedulerLike } from "rxjs";
 
+export type ObservedDecoratorType = 'behavior' | 'subject' | 'replay';
+
 export interface ObservedDecoratorOptions {
-    type: 'behavior' | 'subject' | 'replay';
+    type: ObservedDecoratorType;
     replayOptions?: {
         bufferSize?: number;
         windowTime?: number;

--- a/src/observed.decorator.spec.ts
+++ b/src/observed.decorator.spec.ts
@@ -23,6 +23,12 @@ class TestSubject {
     readonly property$!: Observable<number>;
 }
 
+class TestSubjectShorthand {
+    // @ts-ignore
+    @Observed('subject') property: number;
+    readonly property$!: Observable<number>;
+}
+
 class TestClassNotInitialized implements Test {
     // @ts-ignore
     @Observed() property!: any;
@@ -96,6 +102,19 @@ describe('Observed decorator', () => {
 
     it('should provide correct Subject behavior when using type: subject', () => {
         const classA = new TestSubject();
+
+        expect(classA.property).toBeNull();
+        let spy = spyOn(console, 'log').and.stub();
+
+        classA.property = testValue1;
+        subscription.add(classA.property$.subscribe(value => console.log(value)));
+        classA.property = testValue2;
+
+        expect(spy).toHaveBeenCalledOnceWith(testValue2);
+    });
+
+    it('should provide correct Subject behavior when using \'subject\' shorthand', () => {
+        const classA = new TestSubjectShorthand();
 
         expect(classA.property).toBeNull();
         let spy = spyOn(console, 'log').and.stub();

--- a/src/observed.decorator.ts
+++ b/src/observed.decorator.ts
@@ -85,7 +85,8 @@ export const Observed = (options: ObservedDecoratorType | ObservedDecoratorOptio
 
 namespace ObservedDecorator {
     export function initializeSubject(firstValue: any, options: ObservedDecoratorType | ObservedDecoratorOptions): Subject<any> {
-        switch (getType(options)) {
+        const type = (typeof options === 'string') ? options : options?.type;
+        switch (type) {
             case 'behavior':
                 return new BehaviorSubject(firstValue ?? null);
             case 'subject':
@@ -96,11 +97,5 @@ namespace ObservedDecorator {
             default:
                 return new BehaviorSubject(firstValue ?? null);
         }
-    }
-
-    export function getType(options: ObservedDecoratorType | ObservedDecoratorOptions): ObservedDecoratorType {
-        return (typeof options === 'string')
-            ? options
-            : options?.type;
     }
 }


### PR DESCRIPTION
closes #5 

the unit test actions for this branch can be found [on my local fork](https://github.com/kubikowski/rxjs-observed-decorator/pull/2/checks)